### PR TITLE
make tweaks screen scrollable

### DIFF
--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -5,8 +5,10 @@ import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
@@ -30,10 +32,12 @@ fun TweaksScreen(
     onCategoryButtonClicked: (TweakCategory) -> Unit,
     onNavigationEvent: (String) -> Unit,
 ) {
+    val scrollState = rememberScrollState()
     Column(
         modifier = Modifier
             .fillMaxSize()
-            .padding(16.dp),
+            .padding(16.dp)
+            .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {


### PR DESCRIPTION
## Make TweaksScreen scrollable.
When the elements in the screen exceeds the vertical space in the screen, it's necessary to make the `Column` scrollable:

Before:

https://user-images.githubusercontent.com/944814/154070180-c0a248a1-a783-400e-8334-369bbff93add.mp4



After the fix:
https://user-images.githubusercontent.com/944814/154069914-6bc2975b-f0c1-4d73-b967-7cd1c4668ce6.mp4


