### PR TITLE
add copy to clipboard in readonly tweaks

### DIFF
--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -14,9 +14,11 @@ import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
+import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
@@ -128,6 +130,7 @@ fun ReadOnlyStringTweakEntryBody(
     tweakRowViewModel: ReadOnlyTweakEntryViewModel<String> = ReadOnlyTweakEntryViewModel()
 ) {
     val context = LocalContext.current
+    val clipboardManager = LocalClipboardManager.current
     val value by remember {
         tweakRowViewModel.getValue(entry)
     }.collectAsState(initial = null)
@@ -136,6 +139,12 @@ fun ReadOnlyStringTweakEntryBody(
         onClick = {
             Toast
                 .makeText(context, "${entry.key} = $value", Toast.LENGTH_LONG)
+                .show()
+        },
+        onLongClick = {
+            clipboardManager.setText(AnnotatedString(value.orEmpty()))
+            Toast
+                .makeText(context, "'$value' copied to clipboard", Toast.LENGTH_LONG)
                 .show()
         }) {
         Text(


### PR DESCRIPTION
## Copy to clipboard values

I propose to make the readonly values allowed to be copied to clipboard on `longPress`.

https://user-images.githubusercontent.com/944814/154074636-82c88839-ec27-40c0-8a67-ef0ef4e75c2e.mp4


### Bonus point
I have the following aliases in my dotfiles:
```
alias pbcopy='xclip -selection clipboard'
alias pbpaste='xclip -selection clipboard -o'
alias copyadbclipboard='adb shell am broadcast -n ch.pete.adbclipboard/.ReadReceiver | pbcopy'
``` 
These alias allows me to move the clipboard content from my android device to my computer clipboard