### PR TITLE
Tweak button to allow custom navigations

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,20 @@ fun routeButton(
 ```
 Similar, but this button navigates directly to a route of the NavHost, check [custom screens section](#custom-screens) for more info
 
-
+```kotlin
+customNavigationButton(
+    key = "button 3",
+    name = "Another custom screen button",
+    navigation = { navController ->
+        navController.navigate("custom-screen") {
+            popUpTo("another-custom-screen") {
+                inclusive = true
+            }
+        }
+    }
+)
+```
+Just like `routeButton`, but it allows to pass a lambda which receives a `NavController` so more complex navigations can be performed.
 
 ```kotlin
 fun label(

--- a/app/src/main/java/com/telefonica/tweaks/demo/TweakDemoApplication.kt
+++ b/app/src/main/java/com/telefonica/tweaks/demo/TweakDemoApplication.kt
@@ -57,11 +57,17 @@ private fun demoTweakGraph() = tweaksGraph {
                 Toast.makeText(this@TweakDemoApplication, "Demo button", Toast.LENGTH_LONG)
                     .show()
             }
-
             routeButton(
                 key = "button2",
                 name = "Custom screen button",
                 route = "custom-screen"
+            )
+            customNavigationButton(
+                key = "button 3",
+                name = "Another custom screen button",
+                navigation = { navController ->
+                    navController.navigate("custom-screen")
+                }
             )
         }
     }

--- a/library/src/enabled/java/com/telefonica/tweaks/Tweaks.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/Tweaks.kt
@@ -134,6 +134,10 @@ fun NavGraphBuilder.addTweakGraph(
         navController.navigate(route)
     }
 
+    val onCustomNavigation: ((NavController) -> Unit) -> Unit = { navigation ->
+        navigation.invoke(navController)
+    }
+
     navigation(
         startDestination = TWEAK_MAIN_SCREEN,
         route = TWEAKS_NAVIGATION_ENTRYPOINT,
@@ -144,6 +148,7 @@ fun NavGraphBuilder.addTweakGraph(
                 tweaksGraph = tweaksGraph,
                 onCategoryButtonClicked = { navController.navigate(it.navigationRoute())},
                 onNavigationEvent = onNavigationEvent,
+                onCustomNavigation = onCustomNavigation
             )
         }
 
@@ -152,6 +157,7 @@ fun NavGraphBuilder.addTweakGraph(
                 TweaksCategoryScreen(
                     tweakCategory = category,
                     onNavigationEvent = onNavigationEvent,
+                    onCustomNavigation = onCustomNavigation
                 )
             }
         }

--- a/library/src/enabled/java/com/telefonica/tweaks/domain/TweaksBusinessLogic.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/domain/TweaksBusinessLogic.kt
@@ -119,6 +119,7 @@ class TweaksBusinessLogic @Inject constructor(
         is EditableLongTweakEntry -> longPreferencesKey(entry.key) as Preferences.Key<T>
         is ButtonTweakEntry -> throw java.lang.IllegalStateException("Buttons doesn't have keys")
         is RouteButtonTweakEntry -> throw java.lang.IllegalStateException("Buttons doesn't have keys")
+        is CustomNavigationTweakEntry -> throw java.lang.IllegalStateException("Buttons doesn't have keys")
     }
 
     private fun buildIsOverridenKey(entry: TweakEntry<*>): Preferences.Key<Boolean> =

--- a/library/src/enabled/java/com/telefonica/tweaks/domain/TweaksBusinessLogic.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/domain/TweaksBusinessLogic.kt
@@ -119,7 +119,7 @@ class TweaksBusinessLogic @Inject constructor(
         is EditableLongTweakEntry -> longPreferencesKey(entry.key) as Preferences.Key<T>
         is ButtonTweakEntry -> throw java.lang.IllegalStateException("Buttons doesn't have keys")
         is RouteButtonTweakEntry -> throw java.lang.IllegalStateException("Buttons doesn't have keys")
-        is CustomNavigationTweakEntry -> throw java.lang.IllegalStateException("Buttons doesn't have keys")
+        is CustomNavigationButtonTweakEntry -> throw java.lang.IllegalStateException("Buttons doesn't have keys")
     }
 
     private fun buildIsOverridenKey(entry: TweakEntry<*>): Preferences.Key<Boolean> =

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.navigation.NavController
 import com.telefonica.tweaks.domain.*
 
 @Composable
@@ -33,6 +34,7 @@ fun TweaksScreen(
     tweaksGraph: TweaksGraph,
     onCategoryButtonClicked: (TweakCategory) -> Unit,
     onNavigationEvent: (String) -> Unit,
+    onCustomNavigation: ((NavController) -> Unit) -> Unit
 ) {
     val scrollState = rememberScrollState()
     Column(
@@ -44,7 +46,11 @@ fun TweaksScreen(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
         tweaksGraph.cover?.let {
-            TweakGroupBody(tweakGroup = it, onNavigationEvent = onNavigationEvent)
+            TweakGroupBody(
+                tweakGroup = it,
+                onNavigationEvent = onNavigationEvent,
+                onCustomNavigation = onCustomNavigation
+            )
         }
         tweaksGraph.categories.forEach { category ->
             Button(
@@ -60,6 +66,7 @@ fun TweaksScreen(
 fun TweaksCategoryScreen(
     tweakCategory: TweakCategory,
     onNavigationEvent: (String) -> Unit,
+    onCustomNavigation: ((NavController) -> Unit) -> Unit
 ) {
     val scrollState = rememberScrollState()
     Column(
@@ -73,7 +80,11 @@ fun TweaksCategoryScreen(
         Text(tweakCategory.title, style = MaterialTheme.typography.h4)
 
         tweakCategory.groups.forEach { group ->
-            TweakGroupBody(tweakGroup = group, onNavigationEvent = onNavigationEvent)
+            TweakGroupBody(
+                tweakGroup = group,
+                onNavigationEvent = onNavigationEvent,
+                onCustomNavigation = onCustomNavigation
+            )
         }
     }
 }
@@ -82,6 +93,7 @@ fun TweaksCategoryScreen(
 fun TweakGroupBody(
     tweakGroup: TweakGroup,
     onNavigationEvent: (String) -> Unit,
+    onCustomNavigation: ((NavController) -> Unit) -> Unit
 ) {
     Card(
         elevation = 3.dp
@@ -101,6 +113,7 @@ fun TweakGroupBody(
                     is ReadOnlyStringTweakEntry -> ReadOnlyStringTweakEntryBody(entry, ReadOnlyTweakEntryViewModel())
                     is ButtonTweakEntry -> TweakButton(entry)
                     is RouteButtonTweakEntry -> TweakNavigableButton(entry, onNavigationEvent)
+                    is CustomNavigationTweakEntry -> TweakNavigableButton(entry, onCustomNavigation)
                 }
             }
         }
@@ -124,6 +137,19 @@ fun TweakNavigableButton(
 ) {
     Button(
         onClick = { onClick(entry.route) },
+        modifier = Modifier.fillMaxWidth(),
+    ) {
+        Text(entry.name)
+    }
+}
+
+@Composable
+fun TweakNavigableButton(
+    entry: CustomNavigationTweakEntry,
+    customNavigation: ((NavController) -> Unit) -> Unit
+) {
+    Button(
+        onClick = { customNavigation(entry.navigation) },
         modifier = Modifier.fillMaxWidth(),
     ) {
         Text(entry.name)

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -113,7 +113,7 @@ fun TweakGroupBody(
                     is ReadOnlyStringTweakEntry -> ReadOnlyStringTweakEntryBody(entry, ReadOnlyTweakEntryViewModel())
                     is ButtonTweakEntry -> TweakButton(entry)
                     is RouteButtonTweakEntry -> TweakNavigableButton(entry, onNavigationEvent)
-                    is CustomNavigationTweakEntry -> TweakNavigableButton(entry, onCustomNavigation)
+                    is CustomNavigationButtonTweakEntry -> TweakNavigableButton(entry, onCustomNavigation)
                 }
             }
         }
@@ -145,7 +145,7 @@ fun TweakNavigableButton(
 
 @Composable
 fun TweakNavigableButton(
-    entry: CustomNavigationTweakEntry,
+    entry: CustomNavigationButtonTweakEntry,
     customNavigation: ((NavController) -> Unit) -> Unit
 ) {
     Button(

--- a/library/src/main/java/com/telefonica/tweaks/domain/tweakModels.kt
+++ b/library/src/main/java/com/telefonica/tweaks/domain/tweakModels.kt
@@ -170,7 +170,7 @@ class RouteButtonTweakEntry(key: String, name: String, val route: String) :
 
 /**
  * A button, that when tapped will execute the navigation specified
- * using the NavControlled it receives as param
+ * using the NavController it receives as param
  */
 class CustomNavigationButtonTweakEntry(
     key: String,

--- a/library/src/main/java/com/telefonica/tweaks/domain/tweakModels.kt
+++ b/library/src/main/java/com/telefonica/tweaks/domain/tweakModels.kt
@@ -1,5 +1,6 @@
 package com.telefonica.tweaks.domain
 
+import androidx.navigation.NavController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
@@ -71,6 +72,14 @@ data class TweakGroup(val title: String, val entries: List<TweakEntry<*>>) {
             route: String,
         ) {
             tweak(RouteButtonTweakEntry(key, name, route))
+        }
+
+        fun customNavigationButton(
+            key: String,
+            name: String,
+            navigation: (NavController) -> Unit,
+        ) {
+            tweak(CustomNavigationTweakEntry(key, name, navigation))
         }
 
         fun label(
@@ -158,6 +167,16 @@ class ButtonTweakEntry(key: String, name: String, val action: () -> Unit) :
 /** A button, that when tapped navigates to a route*/
 class RouteButtonTweakEntry(key: String, name: String, val route: String) :
     TweakEntry<Unit>(key, name)
+
+/**
+ * A button, that when tapped will execute the navigation specified
+ * using the NavControlled it receives as param
+ */
+class CustomNavigationTweakEntry(
+    key: String,
+    name: String,
+    val navigation: (NavController) -> Unit
+): TweakEntry<Unit>(key, name)
 
 /** A non editable entry */
 class ReadOnlyStringTweakEntry(key: String, name: String, override val value: Flow<String>) :

--- a/library/src/main/java/com/telefonica/tweaks/domain/tweakModels.kt
+++ b/library/src/main/java/com/telefonica/tweaks/domain/tweakModels.kt
@@ -79,7 +79,7 @@ data class TweakGroup(val title: String, val entries: List<TweakEntry<*>>) {
             name: String,
             navigation: (NavController) -> Unit,
         ) {
-            tweak(CustomNavigationTweakEntry(key, name, navigation))
+            tweak(CustomNavigationButtonTweakEntry(key, name, navigation))
         }
 
         fun label(
@@ -172,7 +172,7 @@ class RouteButtonTweakEntry(key: String, name: String, val route: String) :
  * A button, that when tapped will execute the navigation specified
  * using the NavControlled it receives as param
  */
-class CustomNavigationTweakEntry(
+class CustomNavigationButtonTweakEntry(
     key: String,
     name: String,
     val navigation: (NavController) -> Unit


### PR DESCRIPTION
Create a new `CustomNavigationTweakEntry` entry type and the corresponding DSL method `customNavigationButton`.
It is just like `RouteButtonTweakEntry` but It receives a lambda of type `(NavController) -> Unit)` instead of a `route: String` so a more complex navigation can be performed.