### PR TITLE
ANDROID 11624 - Minor UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,7 +240,19 @@ fun dropDownMenu(
 )
 ```
 A DropDownMenu
-Please review the app module for configuration examples. 
+Please review the app module for configuration examples.
+
+## Reset Button
+When a group of tweaks is created, only if there is at least one editable tweak, a reset button will be automatically added.
+If you do not want the reset button to be added automatically, there is a parameter in group node `hideResetButton` that can be set.
+```kotlin
+group(
+    title = "Group Title",
+    hideResetButton = true
+) {
+    // Your tweaks
+}
+```
 
 ## Custom screens:
 You can add your custom screens to the TweaksGraph by using the `customComposableScreens` parameter of `addTweakGraph` function, for example:

--- a/README.md
+++ b/README.md
@@ -244,11 +244,11 @@ Please review the app module for configuration examples.
 
 ## Reset Button
 When a group of tweaks is created, only if there is at least one editable tweak, a reset button will be automatically added.
-If you do not want the reset button to be added automatically, there is a parameter in group node `hideResetButton` that can be set.
+If you do not want the reset button to be added automatically, there is a parameter in group node `withClearButton` that can be set.
 ```kotlin
 group(
     title = "Group Title",
-    hideResetButton = true
+    withClearButton = true
 ) {
     // Your tweaks
 }

--- a/library/src/enabled/java/com/telefonica/tweaks/TweaksTheme.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/TweaksTheme.kt
@@ -49,7 +49,7 @@ fun DefaultTweaksTheme(
         tweaksBackground = TweaksDarkBlue,
         tweaksOnBackground = Color.White,
         tweaksGroupBackground = TweaksDarkBlueBackground,
-        tweaksColorModified = TweaksDarkBlueBackground,
+        tweaksColorModified = TweaksGreen,
     )
     CompositionLocalProvider(LocalTweaksColors provides tweaksColors) {
         content()

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -304,7 +304,7 @@ fun EditableBooleanTweakEntryBody(
         tweakEntry = entry,
         onClick = {
             Toast
-                .makeText(context, "Current value is $entry.", Toast.LENGTH_LONG)
+                .makeText(context, "Current value is $value.", Toast.LENGTH_LONG)
                 .show()
         },
         shouldShowOverriddenLabel = isOverridden) {

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -61,6 +61,7 @@ import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.font.FontFamily
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.text.input.KeyboardType
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
@@ -264,7 +265,8 @@ fun ReadOnlyStringTweakEntryBody(
         Text(
             text = "$value",
             fontFamily = FontFamily.Monospace,
-            color = TweaksTheme.colors.tweaksOnBackground
+            color = TweaksTheme.colors.tweaksOnBackground,
+            textAlign = TextAlign.End,
         )
     }
 }

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -191,7 +191,7 @@ fun TweakGroupBody(
                 }
             }
 
-            if (tweakGroup.entries.any { it is Editable<*> } && !tweakGroup.hideResetButton) {
+            if (tweakGroup.entries.any { it is Editable<*> } && tweakGroup.withClearButton) {
                 Divider(thickness = 2.dp)
                 ResetButton(onResetClicked = { tweakGroupViewModel.reset(tweakGroup) })
             }

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.RowScope
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -437,7 +438,7 @@ private fun TweakRow(
     content: @Composable RowScope.() -> Unit,
 ) {
     Row(
-        verticalAlignment = Alignment.CenterVertically,
+        verticalAlignment = Alignment.Top,
         horizontalArrangement = Arrangement.SpaceBetween,
         modifier = Modifier
             .fillMaxWidth()
@@ -448,6 +449,7 @@ private fun TweakRow(
             )
     ) {
         TweakNameText(entry = tweakEntry, shouldShowOverriddenLabel = shouldShowOverriddenLabel)
+        Spacer(modifier = Modifier.padding(horizontal = 8.dp))
         content()
     }
 }

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -185,7 +185,8 @@ fun TweakGroupBody(
                         onCustomNavigation)
                 }
             }
-            if (tweakGroup.withClearButton) {
+
+            if (tweakGroup.entries.any { it is Editable<*> } && !tweakGroup.hideResetButton) {
                 Divider(thickness = 2.dp)
                 ResetButton(onResetClicked = { tweakGroupViewModel.reset(tweakGroup) })
             }

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -27,8 +27,10 @@ import androidx.compose.material.ContentAlpha
 import androidx.compose.material.Divider
 import androidx.compose.material.DropdownMenu
 import androidx.compose.material.DropdownMenuItem
+import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
+import androidx.compose.material.LocalMinimumTouchTargetEnforcement
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -38,6 +40,7 @@ import androidx.compose.material.contentColorFor
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
@@ -289,6 +292,7 @@ fun EditableStringTweakEntryBody(
     )
 }
 
+@OptIn(ExperimentalMaterialApi::class)
 @Composable
 fun EditableBooleanTweakEntryBody(
     entry: EditableBooleanTweakEntry,
@@ -308,14 +312,17 @@ fun EditableBooleanTweakEntryBody(
                 .makeText(context, "Current value is $value.", Toast.LENGTH_LONG)
                 .show()
         },
-        shouldShowOverriddenLabel = isOverridden) {
-        Checkbox(
-            checked = value ?: false,
-            onCheckedChange = {
-                tweakRowViewModel.setValue(entry, it)
-            },
-            colors = tweaksCheckboxColors(),
-        )
+        shouldShowOverriddenLabel = isOverridden
+    ) {
+        CompositionLocalProvider(LocalMinimumTouchTargetEnforcement provides false) {
+            Checkbox(
+                checked = value ?: false,
+                onCheckedChange = {
+                    tweakRowViewModel.setValue(entry, it)
+                },
+                colors = tweaksCheckboxColors(),
+            )
+        }
     }
 }
 

--- a/library/src/main/java/com/telefonica/tweaks/domain/tweakModels.kt
+++ b/library/src/main/java/com/telefonica/tweaks/domain/tweakModels.kt
@@ -16,8 +16,8 @@ data class TweaksGraph(val cover: TweakGroup?, val categories: List<TweakCategor
         private val categories = mutableListOf<TweakCategory>()
         private var cover: TweakGroup? = null
 
-        fun cover(title: String, hideResetButton: Boolean = false, block: TweakGroup.Builder.() -> Unit) {
-            val builder = TweakGroup.Builder(title, hideResetButton)
+        fun cover(title: String, withClearButton: Boolean = true, block: TweakGroup.Builder.() -> Unit) {
+            val builder = TweakGroup.Builder(title, withClearButton)
             builder.block()
             cover = builder.build()
         }
@@ -41,10 +41,10 @@ data class TweakCategory(val title: String, val groups: List<TweakGroup>) {
 
         fun group(
             title: String,
-            hideResetButton: Boolean = false,
+            withClearButton: Boolean = true,
             block: TweakGroup.Builder.() -> Unit,
         ) {
-            val builder = TweakGroup.Builder(title, hideResetButton)
+            val builder = TweakGroup.Builder(title, withClearButton)
             builder.block()
             groups.add(builder.build())
         }
@@ -54,10 +54,10 @@ data class TweakCategory(val title: String, val groups: List<TweakGroup>) {
 }
 
 /** A bunch of tweaks that are related to each other, for example: domain & port for the backend server configurations*/
-data class TweakGroup(val title: String, val hideResetButton: Boolean = false, val entries: List<TweakEntry>) {
+data class TweakGroup(val title: String, val withClearButton: Boolean = true, val entries: List<TweakEntry>) {
     class Builder(
         private val title: String,
-        private val hideResetButton: Boolean = false,
+        private val withClearButton: Boolean = true,
     ) {
         private val entries = mutableListOf<TweakEntry>()
 
@@ -166,7 +166,7 @@ data class TweakGroup(val title: String, val hideResetButton: Boolean = false, v
             tweak(DropDownMenuTweakEntry(key, name, values, defaultValue))
         }
 
-        internal fun build(): TweakGroup = TweakGroup(title, hideResetButton, entries)
+        internal fun build(): TweakGroup = TweakGroup(title, withClearButton, entries)
     }
 }
 

--- a/library/src/main/java/com/telefonica/tweaks/domain/tweakModels.kt
+++ b/library/src/main/java/com/telefonica/tweaks/domain/tweakModels.kt
@@ -16,8 +16,8 @@ data class TweaksGraph(val cover: TweakGroup?, val categories: List<TweakCategor
         private val categories = mutableListOf<TweakCategory>()
         private var cover: TweakGroup? = null
 
-        fun cover(title: String, withClearButton: Boolean = false, block: TweakGroup.Builder.() -> Unit) {
-            val builder = TweakGroup.Builder(title, withClearButton)
+        fun cover(title: String, hideResetButton: Boolean = false, block: TweakGroup.Builder.() -> Unit) {
+            val builder = TweakGroup.Builder(title, hideResetButton)
             builder.block()
             cover = builder.build()
         }
@@ -41,10 +41,10 @@ data class TweakCategory(val title: String, val groups: List<TweakGroup>) {
 
         fun group(
             title: String,
-            withClearButton: Boolean = true,
+            hideResetButton: Boolean = false,
             block: TweakGroup.Builder.() -> Unit,
         ) {
-            val builder = TweakGroup.Builder(title, withClearButton)
+            val builder = TweakGroup.Builder(title, hideResetButton)
             builder.block()
             groups.add(builder.build())
         }
@@ -54,10 +54,10 @@ data class TweakCategory(val title: String, val groups: List<TweakGroup>) {
 }
 
 /** A bunch of tweaks that are related to each other, for example: domain & port for the backend server configurations*/
-data class TweakGroup(val title: String, val withClearButton: Boolean = true, val entries: List<TweakEntry>) {
+data class TweakGroup(val title: String, val hideResetButton: Boolean = false, val entries: List<TweakEntry>) {
     class Builder(
         private val title: String,
-        private val withClearButton: Boolean = true,
+        private val hideResetButton: Boolean = false,
     ) {
         private val entries = mutableListOf<TweakEntry>()
 
@@ -166,7 +166,7 @@ data class TweakGroup(val title: String, val withClearButton: Boolean = true, va
             tweak(DropDownMenuTweakEntry(key, name, values, defaultValue))
         }
 
-        internal fun build(): TweakGroup = TweakGroup(title, withClearButton, entries)
+        internal fun build(): TweakGroup = TweakGroup(title, hideResetButton, entries)
     }
 }
 


### PR DESCRIPTION
The reset button is now only assigned when there is an editable within the group. It can be overridden by indicating hideResetButton.

Certain UI improvements listed here:
* Checkbox Paddings.
* Checkbox toast value.
* Readable Tweaks value align and padding.
* Modified label color changed.

![Screenshot 2023-02-09 at 09 38 27](https://user-images.githubusercontent.com/8106237/217760213-f32bb570-e0f8-4c5d-988c-f1d7d434dce1.png)


|   | Before  |  After |
|---|---|---|
| Padding & Boolean Value | ![Screenshot_20230207_172207](https://user-images.githubusercontent.com/8106237/217312444-e1c17015-5a05-4970-82cb-5a13ecbfb3c0.png)  | ![Screenshot_20230207_175117](https://user-images.githubusercontent.com/8106237/217312528-299feba9-0b12-4640-aee4-1301f8d38198.png)  |
| Padding & Align | ![Screenshot_20230207_172229](https://user-images.githubusercontent.com/8106237/217312445-fb585107-4fb1-4604-9064-87415ffc22de.png)  | ![Screenshot_20230207_175419](https://user-images.githubusercontent.com/8106237/217312529-f834fd9d-ef41-4637-bc98-c61d6f2c453c.png)  |









