### PR TITLE
Manual trigger of action Generate release for testing purposes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,8 @@
 name: "Create release"
-on: 
+on:
   release:
       types: [published]
+  workflow_dispatch:
 jobs:
   release:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Enable manual trigger of action Generate release for testing purposes.
This change will be undo in the next PR