### PR TITLE
Fix upload to sonatype step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,10 +20,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }} publishNoopPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}"
-
-      - name: Close and promote staging repository
-        env:
-          MOBILE_MAVENCENTRAL_USER: ${{ secrets.MOBILE_MAVENCENTRAL_USER }}
-          MOBILE_MAVENCENTRAL_PASSWORD: ${{ secrets.MOBILE_MAVENCENTRAL_PASSWORD }}
-        run: 'bash ./gradlew closeAndReleaseStagingRepository'
+        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=2.2.2 publishNoopPublicationToSonatypeRepository -DLIBRARY_VERSION=2.2.2
+        --max-workers 1 closeAndReleaseStagingRepository"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,6 @@ name: "Create release"
 on:
   release:
       types: [published]
-  workflow_dispatch:
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -20,5 +19,5 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=2.2.2 publishNoopPublicationToSonatypeRepository -DLIBRARY_VERSION=2.2.2
+        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }} publishNoopPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }}
         --max-workers 1 closeAndReleaseStagingRepository"


### PR DESCRIPTION
Fix step closeSonatypeStagingRepositoryFix from Create release action which was failing after updating nexus plugin plugin in [this PR](https://github.com/Telefonica/tweaks/pull/25)
Tested with Release 2.2.2
https://central.sonatype.com/artifact/com.telefonica/tweaks-no-op/2.2.2