### PR TITLE
Set rootProject.name to lower case

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,6 +6,6 @@ dependencyResolutionManagement {
         mavenCentral()
     }
 }
-rootProject.name = "Tweaks"
+rootProject.name = "tweaks"
 include ':app'
 include ':library'


### PR DESCRIPTION
When cloning project from scratch and opening with Android Studio it throws an error:
"java.lang.IllegalStateException: Module entity with name: Tweaks should be available". 

It seems related with the upper case so it has been changed to "tweaks" in settings.gradle