### PR TITLE
Update AGP, Kotlin, Compose, Api level and other dependecies

### DIFF
--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/manual_release.yml
+++ b/.github/workflows/manual_release.yml
@@ -12,6 +12,12 @@ jobs:
       - name: Checkout repo
         uses: actions/checkout@v2
 
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Build library
         run: 'bash ./gradlew clean :library:assembleRelease'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,13 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
-        
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
+
       - name: Build library
         run: 'bash ./gradlew clean :library:assembleRelease'
           

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -13,7 +13,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -11,6 +11,12 @@ jobs:
     steps:
       - name: Checkout repo
         uses: actions/checkout@v2
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
+        with:
+          distribution: 'temurin'
+          java-version: '17'
         
       - name: Build library
         run: 'bash ./gradlew clean :library:assembleRelease'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,11 +7,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
 
       - name: Setup Gradle
         uses: gradle/gradle-build-action@v2

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -4,12 +4,13 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    namespace "com.telefonica.tweaks.demo"
+    compileSdk 34
 
     defaultConfig {
         applicationId "com.telefonica.tweaks.demo"
         minSdk 21
-        targetSdk 33
+        targetSdk 34
         versionCode 1
         versionName "1.0"
 
@@ -28,11 +29,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '11'
+        jvmTarget = '17'
     }
     buildFeatures {
         compose true
@@ -55,20 +56,23 @@ android {
 dependencies {
 
     implementation project(':library')
-    implementation 'androidx.core:core-ktx:1.9.0'
-    implementation 'androidx.appcompat:appcompat:1.5.1'
-    implementation 'com.google.android.material:material:1.7.0'
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.compose.material:material:$compose_material_version"
-    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    implementation 'androidx.activity:activity-compose:1.6.1'
+    implementation 'androidx.core:core-ktx:1.13.0'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
+    implementation 'com.google.android.material:material:1.11.0'
 
-    implementation("androidx.navigation:navigation-compose:2.6.0-alpha04")
+    implementation platform("androidx.compose:compose-bom:$compose_bom_version")
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.material:material"
+    implementation "androidx.compose.ui:ui-tooling-preview"
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    implementation 'androidx.activity:activity-compose:1.9.0'
+
+    implementation("androidx.navigation:navigation-compose:2.7.7")
 
     testImplementation 'junit:junit:4.13.2'
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation platform("androidx.compose:compose-bom:$compose_bom_version")
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
+    debugImplementation "androidx.compose.ui:ui-tooling"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ buildscript {
 plugins {
     id("io.gitlab.arturbosch.detekt").version("1.18.1")
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0' apply false
+    id("com.google.devtools.ksp") version "1.9.23-1.0.20" apply false
 }
 
 detekt {

--- a/build.gradle
+++ b/build.gradle
@@ -1,11 +1,10 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        compose_compiler_version = '1.4.2'
-        kotlin_version = '1.8.10'
-        compose_version = '1.3.2'
-        compose_material_version = '1.4.0'
-        dagger_version = "2.43.2"
+        compose_compiler_version = '1.5.12'
+        compose_bom_version = '2024.04.01'
+        kotlin_version = '1.9.23'
+        dagger_version = "2.51.1"
     }
     repositories {
         google()
@@ -15,7 +14,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.4.2'
+        classpath 'com.android.tools.build:gradle:8.2.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
     }

--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,6 @@ buildscript {
 plugins {
     id("io.gitlab.arturbosch.detekt").version("1.18.1")
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0' apply false
-    id("com.google.devtools.ksp") version "1.9.23-1.0.20" apply false
 }
 
 detekt {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Oct 06 17:13:45 CEST 2021
+#Tue Apr 23 11:46:57 CEST 2024
 distributionBase=GRADLE_USER_HOME
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-bin.zip
 distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
 zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'com.google.devtools.ksp'
+    id 'kotlin-kapt'
 }
 
 android {
@@ -69,8 +69,8 @@ dependencies {
 
     //Dagger
     enabledImplementation "com.google.dagger:dagger-android-support:$dagger_version"
-    ksp "com.google.dagger:dagger-compiler:$dagger_version"
-    ksp "com.google.dagger:dagger-android-processor:$dagger_version"
+    kapt "com.google.dagger:dagger-compiler:$dagger_version"
+    kapt "com.google.dagger:dagger-android-processor:$dagger_version"
 
 
     testImplementation 'junit:junit:4.13.2'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'com.android.library'
     id 'kotlin-android'
-    id 'kotlin-kapt'
+    id 'com.google.devtools.ksp'
 }
 
 android {
@@ -69,8 +69,8 @@ dependencies {
 
     //Dagger
     enabledImplementation "com.google.dagger:dagger-android-support:$dagger_version"
-    kapt "com.google.dagger:dagger-compiler:$dagger_version"
-    kapt "com.google.dagger:dagger-android-processor:$dagger_version"
+    ksp "com.google.dagger:dagger-compiler:$dagger_version"
+    ksp "com.google.dagger:dagger-android-processor:$dagger_version"
 
 
     testImplementation 'junit:junit:4.13.2'

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -5,11 +5,12 @@ plugins {
 }
 
 android {
-    compileSdk 33
+    namespace "com.telefonica.tweaks"
+    compileSdk 34
 
     defaultConfig {
         minSdk 21
-        targetSdk 33
+        targetSdk 34
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -21,11 +22,11 @@ android {
         }
     }
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_11
-        targetCompatibility JavaVersion.VERSION_11
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
     }
     kotlinOptions {
-        jvmTarget = '11'
+        jvmTarget = '17'
     }
     buildFeatures {
         compose true
@@ -52,17 +53,19 @@ android {
 
 dependencies {
 
-    enabledImplementation 'androidx.core:core-ktx:1.9.0'
-    enabledImplementation 'androidx.appcompat:appcompat:1.5.1'
-    enabledImplementation 'com.google.android.material:material:1.7.0'
-    enabledImplementation "androidx.compose.material:material:$compose_material_version"
-    enabledImplementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
-    enabledImplementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.5.1'
-    enabledImplementation 'androidx.activity:activity-compose:1.6.1'
+    enabledImplementation 'androidx.core:core-ktx:1.13.0'
+    enabledImplementation 'androidx.appcompat:appcompat:1.6.1'
+    enabledImplementation 'com.google.android.material:material:1.11.0'
+
+    enabledImplementation platform("androidx.compose:compose-bom:$compose_bom_version")
+    enabledImplementation "androidx.compose.material:material"
+    enabledImplementation "androidx.compose.ui:ui-tooling-preview"
+    enabledImplementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
+    enabledImplementation 'androidx.activity:activity-compose:1.9.0'
     enabledImplementation 'com.squareup:seismic:1.0.3'
-    enabledImplementation "androidx.datastore:datastore-preferences:1.0.0"
-    implementation "androidx.compose.ui:ui:$compose_version"
-    implementation "androidx.navigation:navigation-compose:2.6.0"
+    enabledImplementation "androidx.datastore:datastore-preferences:1.1.0"
+    implementation "androidx.compose.ui:ui"
+    implementation "androidx.navigation:navigation-compose:2.7.7"
 
     //Dagger
     enabledImplementation "com.google.dagger:dagger-android-support:$dagger_version"
@@ -71,12 +74,13 @@ dependencies {
 
 
     testImplementation 'junit:junit:4.13.2'
-    testImplementation "org.mockito.kotlin:mockito-kotlin:4.0.0"
+    testImplementation "org.mockito.kotlin:mockito-kotlin:5.2.1"
 
-    androidTestImplementation 'androidx.test.ext:junit:1.1.4'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.0'
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
-    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
+    androidTestImplementation platform("androidx.compose:compose-bom:$compose_bom_version")
+    androidTestImplementation 'androidx.test.ext:junit:1.1.5'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
+    debugImplementation "androidx.compose.ui:ui-tooling"
 }
 
 apply from: "${rootProject.projectDir}/mavencentral.gradle"

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -30,7 +30,7 @@ import androidx.compose.material.DropdownMenuItem
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
-import androidx.compose.material.LocalMinimumTouchTargetEnforcement
+import androidx.compose.material.LocalMinimumInteractiveComponentEnforcement
 import androidx.compose.material.MaterialTheme
 import androidx.compose.material.Text
 import androidx.compose.material.TextField
@@ -44,11 +44,11 @@ import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
@@ -287,7 +287,6 @@ fun ReadOnlyStringTweakEntryBody(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun EditableStringTweakEntryBody(
     tweakRowViewModel: EditableTweakEntryViewModel<String>,
@@ -323,7 +322,7 @@ fun EditableBooleanTweakEntryBody(
         },
         shouldShowOverriddenLabel = isOverridden
     ) {
-        CompositionLocalProvider(LocalMinimumTouchTargetEnforcement provides false) {
+        CompositionLocalProvider(LocalMinimumInteractiveComponentEnforcement provides false) {
             Checkbox(
                 checked = tweakRowViewModel.value ?: false,
                 onCheckedChange = {
@@ -335,7 +334,6 @@ fun EditableBooleanTweakEntryBody(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun EditableIntTweakEntryBody(
     tweakRowViewModel: EditableTweakEntryViewModel<Int>,
@@ -356,7 +354,6 @@ fun EditableIntTweakEntryBody(
     )
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 fun EditableLongTweakEntryBody(
     tweakRowViewModel: EditableTweakEntryViewModel<Long>,
@@ -385,7 +382,7 @@ fun DropDownMenuTweakEntryBody(
     var expanded by remember { mutableStateOf(false) }
 
     var selectedIndex by remember {
-        mutableStateOf(max(items.indexOf(tweakRowViewModel.value), 0))
+        mutableIntStateOf(max(items.indexOf(tweakRowViewModel.value), 0))
     }
 
     val isOverridden by remember { tweakRowViewModel.isOverridden() }.collectAsState(initial = false)
@@ -454,7 +451,6 @@ private fun TweakRow(
     }
 }
 
-@OptIn(ExperimentalComposeUiApi::class)
 @Composable
 private fun <T> TweakRowWithEditableTextField(
     value: T?,


### PR DESCRIPTION
### :goal_net: What's the goal?
Update AGP, Kotlin, Compose, Api level and other dependencies

### :construction: How do we do it?
- Kotlin to 1.9.23
- Use latest BOM at the moment: 2024.04.01
- Use corresponding kotlin compose compiler version according to [this table](https://developer.android.com/jetpack/androidx/releases/compose-kotlin): 1.5.12 in this case
- AGP 8.2.2
- Target and compile sdk to 34
- Java 17
- Update every other dependencies

### :blue_book: Documentation changes?
- [x] No docs to update nor create

### :test_tube: How can I test this?
- [x] Everything looks ok in demo app
