### PR TITLE
Remove BOM

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,10 +60,10 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.11.0'
 
-    implementation platform("androidx.compose:compose-bom:$compose_bom_version")
-    implementation "androidx.compose.ui:ui"
-    implementation "androidx.compose.material:material"
-    implementation "androidx.compose.ui:ui-tooling-preview"
+    //noinspection BomWithoutPlatform
+    implementation "androidx.compose.ui:ui:$compose_version"
+    implementation "androidx.compose.material:material:$compose_version"
+    implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
     implementation 'androidx.activity:activity-compose:1.9.0'
 
@@ -72,7 +72,7 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    androidTestImplementation platform("androidx.compose:compose-bom:$compose_bom_version")
-    androidTestImplementation "androidx.compose.ui:ui-test-junit4"
-    debugImplementation "androidx.compose.ui:ui-tooling"
+    //noinspection BomWithoutPlatform
+    androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
+    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -60,7 +60,6 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.11.0'
 
-    //noinspection BomWithoutPlatform
     implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.compose.material:material:$compose_version"
     implementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
@@ -72,7 +71,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
-    //noinspection BomWithoutPlatform
     androidTestImplementation "androidx.compose.ui:ui-test-junit4:$compose_version"
     debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,8 @@
 buildscript {
     ext {
         compose_compiler_version = '1.5.12'
-        compose_bom_version = '2024.04.01'
+        compose_version = '1.6.6'
+
         kotlin_version = '1.9.23'
         dagger_version = "2.51.1"
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -57,14 +57,14 @@ dependencies {
     enabledImplementation 'androidx.appcompat:appcompat:1.6.1'
     enabledImplementation 'com.google.android.material:material:1.11.0'
 
-    enabledImplementation platform("androidx.compose:compose-bom:$compose_bom_version")
-    enabledImplementation "androidx.compose.material:material"
-    enabledImplementation "androidx.compose.ui:ui-tooling-preview"
+    //noinspection BomWithoutPlatform
+    enabledImplementation "androidx.compose.material:material:$compose_version"
+    enabledImplementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     enabledImplementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
     enabledImplementation 'androidx.activity:activity-compose:1.9.0'
     enabledImplementation 'com.squareup:seismic:1.0.3'
     enabledImplementation "androidx.datastore:datastore-preferences:1.1.0"
-    implementation "androidx.compose.ui:ui"
+    implementation "androidx.compose.ui:ui:$compose_version"
     implementation "androidx.navigation:navigation-compose:2.7.7"
 
     //Dagger
@@ -76,11 +76,11 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito.kotlin:mockito-kotlin:5.2.1"
 
-    androidTestImplementation platform("androidx.compose:compose-bom:$compose_bom_version")
+    //noinspection BomWithoutPlatform
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4"
-    debugImplementation "androidx.compose.ui:ui-tooling"
+    debugImplementation "androidx.compose.ui:ui-tooling:$compose_version"
 }
 
 apply from: "${rootProject.projectDir}/mavencentral.gradle"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -57,7 +57,6 @@ dependencies {
     enabledImplementation 'androidx.appcompat:appcompat:1.6.1'
     enabledImplementation 'com.google.android.material:material:1.11.0'
 
-    //noinspection BomWithoutPlatform
     enabledImplementation "androidx.compose.material:material:$compose_version"
     enabledImplementation "androidx.compose.ui:ui-tooling-preview:$compose_version"
     enabledImplementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.7.0'
@@ -76,7 +75,6 @@ dependencies {
     testImplementation 'junit:junit:4.13.2'
     testImplementation "org.mockito.kotlin:mockito-kotlin:5.2.1"
 
-    //noinspection BomWithoutPlatform
     androidTestImplementation 'androidx.test.ext:junit:1.1.5'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.5.1'
     androidTestImplementation "androidx.compose.ui:ui-test-junit4"


### PR DESCRIPTION
### :goal_net: What's the goal?
Same problem described in this PR https://github.com/Telefonica/mistica-android/pull/230

### :construction: How do we do it?
Do not use Compose Bom and use explicit version of each compose dependency. Fortunately it is the same for every of it. I used 1.6.6 version, the one corresponding to "2024.04.01" BOM (defined in this mappings table https://developer.android.com/develop/ui/compose/bom/bom-mapping)

### :blue_book: Documentation changes?
- [x] No docs to update nor create

### :test_tube: How can I test this?
- [x] Manually tested, everything works as before
