### PR TITLE
ANDROID-15323 Open tweaks as single top

### DIFF
--- a/library/src/enabled/java/com/telefonica/tweaks/Tweaks.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/Tweaks.kt
@@ -95,7 +95,9 @@ open class Tweaks : TweaksContract {
 @Composable
 fun NavController.navigateToTweaksOnShake() {
     DetectShakeAndNavigate {
-        navigate(TWEAKS_NAVIGATION_ENTRYPOINT)
+        navigate(TWEAKS_NAVIGATION_ENTRYPOINT) {
+            launchSingleTop = true
+        }
     }
 }
 


### PR DESCRIPTION
### :goal_net: What's the goal?
We are exposiing the "open tweaks when shaking" with a `navigateToTweaksOnShake` method. However if more than one shake is detected multiple tweaks screens are opened and added to the navigation stack, forcing the user to press back several times to exit tweaks .

 We should open just one instance of tweaks even if multiple shakes are detected.

### :construction: How do we do it?
Set `launchSingleTop` to `true` when navigating to `TWEAKS_NAVIGATION_ENTRYPOINT`.

### :blue_book: Documentation changes?
- [x] No docs to update nor create

### :test_tube: How can I test this?
- [x] Before and after video

#### Before

https://github.com/user-attachments/assets/afa4b5fc-cca2-44c2-a994-9cc250afec84

#### After

https://github.com/user-attachments/assets/4564ca6b-494e-44cf-bb3b-84be1e156ac1



