### PR TITLE
ANDROID-16118 Escape release notes to avoid problems with multiline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,14 @@ jobs:
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
         run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }} publishNoopPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }} --max-workers 1 closeAndReleaseStagingRepository"
 
+      - name: Prepare release notes
+        run: |
+          RELEASE_BODY=$(jq -Rs . <<'EOF'
+          ${{ github.event.release.body }}
+          EOF
+          )
+          echo "FORMATTED_BODY=${RELEASE_BODY}" >> $GITHUB_ENV
+
       - name: Send Teams notification
         uses: fjogeleit/http-request-action@v1.16.4
         with:
@@ -75,7 +83,7 @@ jobs:
                     },
                     {
                       "type": "TextBlock",
-                      "text": "${{ github.event.release.body }}",
+                      "text": ${{ env.FORMATTED_BODY }},
                       "wrap": true
                     },
                     {


### PR DESCRIPTION
### :goal_net: What's the goal?
Escape release notes to avoid problems with multiline.

Similar to Mistica PR https://github.com/Telefonica/mistica-android/pull/419

### :blue_book: Documentation changes?
- [x] No docs to update nor create

### :test_tube: How can I test this?
Tested with Mistica repo
