### PR TITLE
ANDROID-16206 Migrate Sonatype publishing to Central Portal

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEY }}
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGPASSWORD }}
           ORG_GRADLE_PROJECT_signingKeyId: ${{ secrets.ORG_GRADLE_PROJECT_SIGNINGKEYID }}
-        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }} publishNoopPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }} --max-workers 1 closeAndReleaseStagingRepository"
+        run: "bash ./gradlew publishReleasePublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }} publishNoopPublicationToSonatypeRepository -DLIBRARY_VERSION=${{ github.event.release.tag_name }} --max-workers 1 closeAndReleaseStagingRepositories"
 
       - name: Prepare release notes
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -24,7 +24,7 @@ buildscript {
 
 plugins {
     id("io.gitlab.arturbosch.detekt").version("1.18.1")
-    id 'io.github.gradle-nexus.publish-plugin' version '1.3.0' apply false
+    id 'io.github.gradle-nexus.publish-plugin' version '2.0.0' apply false
 }
 
 detekt {

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,8 +19,5 @@ kapt.incremental.apt=true
 # It's going to be deleted in Kotlin 1.8
 kapt.use.worker.api=true
 
-# This will be default on AGP 8.0
-android.r8.failOnMissingClasses=true
-
 ###### Project settings ######
 kotlin.code.style=official

--- a/publish_maven_central.gradle
+++ b/publish_maven_central.gradle
@@ -6,6 +6,8 @@ nexusPublishing {
             stagingProfileId = "f7fe7699e57a"
             username = System.getenv("MOBILE_MAVENCENTRAL_USER")
             password = System.getenv("MOBILE_MAVENCENTRAL_PASSWORD")
+            nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+            snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
         }
     }
 }


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-16206](https://jira.tid.es/browse/ANDROID-16206)

### :goal_net: What's the goal?
Migrate Sonatype publishing to Central Portal following the [migration guide](https://confluence.tid.es/pages/viewpage.action?spaceKey=CTO&title=Migration+from+OSSRH+to+Central+Portal#Updating+Open+Source+Projects).

### :construction: How do we do it?
* Update the Gradle Nexus Publish Plugin to version 2.0.0, which supports Central Portal.
* Add the new nexus URLs and snapshot repository URLs under the sonatype block.
* Replace closeAndReleaseStagingRepository with closeAndReleaseStagingRepositories, as this is required by the new plugin version for compatibility with Central Portal.

ℹ️ **Not related** (poyake): Remove this declaration `android.r8.failOnMissingClasses=true` since it is ignored and `true` by default in AGP >= 8.0 (current is 8.2.2)

### :blue_book: Documentation changes?
https://confluence.tid.es/pages/viewpage.action?spaceKey=CTO&title=Migration+from+OSSRH+to+Central+Portal#Updating+Open+Source+Projects

### :test_tube: How can I test this?
Snapshot artifact has been uploaded successfully in Central Portal: 5.0.1.1-SNAPSHOT
https://github.com/Telefonica/tweaks/actions/runs/15728382440
https://central.sonatype.com/service/rest/repository/browse/maven-snapshots/com/telefonica/tweaks/