### PR TITLE
ANDROID-16185 - Update compile and targetSdk to Android 16

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -5,12 +5,12 @@ plugins {
 
 android {
     namespace "com.telefonica.tweaks.demo"
-    compileSdk 34
+    compileSdk 36
 
     defaultConfig {
         applicationId "com.telefonica.tweaks.demo"
         minSdk 21
-        targetSdk 34
+        targetSdk 36
         versionCode 1
         versionName "1.0"
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -6,11 +6,11 @@ plugins {
 
 android {
     namespace "com.telefonica.tweaks"
-    compileSdk 34
+    compileSdk 36
 
     defaultConfig {
         minSdk 21
-        targetSdk 34
+        targetSdk 36
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -1,5 +1,6 @@
 package com.telefonica.tweaks.ui
 
+import android.content.res.Configuration
 import android.widget.Toast
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
@@ -10,13 +11,20 @@ import androidx.compose.foundation.layout.ColumnScope
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
+import androidx.compose.foundation.layout.WindowInsetsSides
+import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
+import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.statusBars
+import androidx.compose.foundation.layout.systemGestures
+import androidx.compose.foundation.layout.union
 import androidx.compose.foundation.layout.windowInsetsBottomHeight
+import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.foundation.layout.windowInsetsTopHeight
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardActions
@@ -57,6 +65,7 @@ import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.focus.focusRequester
 import androidx.compose.ui.graphics.compositeOver
 import androidx.compose.ui.platform.LocalClipboardManager
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
 import androidx.compose.ui.platform.SoftwareKeyboardController
@@ -99,11 +108,12 @@ fun TweaksScreen(
             .fillMaxSize()
             .background(TweaksTheme.colors.tweaksBackground)
             .padding(horizontal = 16.dp)
+            .edgeToEdgeInsetsForOrientation()
             .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        Spacer(modifier = Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
+//        Spacer(modifier = Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
 
         tweaksGraph.cover?.let {
             TweakGroupBody(
@@ -118,7 +128,7 @@ fun TweaksScreen(
                 text = category.title,
             )
         }
-        Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
+//        Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
     }
 }
 
@@ -134,6 +144,7 @@ fun TweaksCategoryScreen(
             .fillMaxSize()
             .background(TweaksTheme.colors.tweaksBackground)
             .padding(horizontal = 16.dp)
+            .edgeToEdgeInsetsForOrientation()
             .verticalScroll(scrollState),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -600,4 +611,27 @@ internal fun TweakButton(
             color = TweaksTheme.colors.tweaksOnPrimary,
         )
     }
+}
+
+@Composable
+fun Modifier.edgeToEdgeInsetsForOrientation(includeIme: Boolean = true): Modifier {
+    val isLandscape =
+        LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
+
+    val sides =
+        if (isLandscape) WindowInsetsSides.Top + WindowInsetsSides.Horizontal
+        else WindowInsetsSides.Top + WindowInsetsSides.Bottom
+
+    var base = WindowInsets.statusBars
+        .union(WindowInsets.navigationBars)
+        .union(WindowInsets.displayCutout)
+        .union(WindowInsets.systemGestures)
+        .only(sides)
+
+    if (includeIme && !isLandscape) {
+        // In portrait mode: is add the IME space
+        base = base.union(WindowInsets.ime.only(WindowInsetsSides.Bottom))
+    }
+
+    return this.windowInsetsPadding(base)
 }

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -15,7 +15,6 @@ import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.displayCutout
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.ime
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
 import androidx.compose.foundation.layout.padding

--- a/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
+++ b/library/src/enabled/java/com/telefonica/tweaks/ui/TweakComponents.kt
@@ -113,8 +113,6 @@ fun TweaksScreen(
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-//        Spacer(modifier = Modifier.windowInsetsTopHeight(WindowInsets.statusBars))
-
         tweaksGraph.cover?.let {
             TweakGroupBody(
                 tweakGroup = it,
@@ -128,7 +126,6 @@ fun TweaksScreen(
                 text = category.title,
             )
         }
-//        Spacer(modifier = Modifier.windowInsetsBottomHeight(WindowInsets.navigationBars))
     }
 }
 
@@ -614,7 +611,7 @@ internal fun TweakButton(
 }
 
 @Composable
-fun Modifier.edgeToEdgeInsetsForOrientation(includeIme: Boolean = true): Modifier {
+fun Modifier.edgeToEdgeInsetsForOrientation(): Modifier {
     val isLandscape =
         LocalConfiguration.current.orientation == Configuration.ORIENTATION_LANDSCAPE
 
@@ -627,11 +624,6 @@ fun Modifier.edgeToEdgeInsetsForOrientation(includeIme: Boolean = true): Modifie
         .union(WindowInsets.displayCutout)
         .union(WindowInsets.systemGestures)
         .only(sides)
-
-    if (includeIme && !isLandscape) {
-        // In portrait mode: is add the IME space
-        base = base.union(WindowInsets.ime.only(WindowInsetsSides.Bottom))
-    }
 
     return this.windowInsetsPadding(base)
 }


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-16185](https://jira.tid.es/browse/ANDROID-16185)

### :goal_net: What's the goal?
Update `compileSdk` and `targetSdk` values to Android 16

### :construction: How do we do it?
* Modifying in `build.gradle`, from `:library` module with corresponding API 36 values.
* In `TweakComponents.kt` file, concretely in `TweaksScreen()` and `TwekasCategoryScreen()` is defined a `Modifier.edgeToEdgeInsetsForOrientation()` to apply correctly corresponding insets depending on portrait or landscape mode.

### :blue_book: Documentation changes?
- [X] No docs to update nor create
