### PR TITLE
ANDROID-17068 android gradle plugin updated to version 8.13.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ buildscript {
         }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.2.2'
+        classpath 'com.android.tools.build:gradle:8.13.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath "io.codearte.gradle.nexus:gradle-nexus-staging-plugin:0.30.0"
     }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Tue Apr 23 11:46:57 CEST 2024
+#Fri Nov 21 13:24:17 CET 2025
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
### :tickets: Jira ticket
[ANDROID-17068](https://jira.tid.es/browse/ANDROID-17068)

### :goal_net: What's the goal?
_We need to update the android gradle plugin version to `8.13.1`._

### :construction: How do we do it?
Replace in app's `build.gradle`:
```
classpath 'com.android.tools.build:gradle:8.2.2'
```
with 
```
classpath 'com.android.tools.build:gradle:8.13.1'
```

Use `gradle-8.13-bin.zip` instead of `gradle-8.2-bin.zip` in `gradle-wrapper.properties`